### PR TITLE
Disable server_tokens to not leak Nginx version and hide X-Powered-By header

### DIFF
--- a/nginx_default.conf
+++ b/nginx_default.conf
@@ -22,6 +22,7 @@ server {
     }
 
     location ~ ^/index\.php(/|$) {
+        fastcgi_hide_header X-Powered-By;
         fastcgi_pass kimai:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;

--- a/nginx_default.conf
+++ b/nginx_default.conf
@@ -2,6 +2,7 @@ server {
     listen 80;
     index index.php;
     server_name nginx;
+    server_tokens off;
     root /opt/kimai/public;
 
     # cache static asset files


### PR DESCRIPTION
Disable exposing the Nginx version number to clients and also hide X-Powered-By header to not expose upstream details such as potentially the used PHP version.

More details: https://blog.livebyt.es/turn-off-your-server-tokens/

| Before | After | 
|---|---|
| <img width="271" alt="Bildschirmfoto 2022-02-18 um 07 47 21" src="https://user-images.githubusercontent.com/126418/154632113-1735d797-851c-4830-82b2-2b35531c2465.png"> | <img width="455" alt="Bildschirmfoto 2022-02-18 um 07 46 45" src="https://user-images.githubusercontent.com/126418/154632148-2670ebde-316a-4508-87d7-f8ee56a65e9d.png"> |